### PR TITLE
Fixing so that target slide centers correctly

### DIFF
--- a/src/mixins/trackHelper.js
+++ b/src/mixins/trackHelper.js
@@ -144,7 +144,7 @@ export var getTrackLeft = function (spec) {
           }
 
           if (targetSlide) {
-            targetLeft = targetSlide.offsetLeft * -1 + (spec.listWidth - targetSlide.offsetWidth) / 2;
+            targetLeft = targetSlide.offsetLeft * -1 + (spec.slideWidth - targetSlide.offsetWidth) / 2;
           }
       }
   }


### PR DESCRIPTION
Modifying `getTrackLeft` function where `spec.variableWidth` is `true` and `spec.centerMode` is `true`.  

Previously,  `spec.listWidth` was used to determine how far to offset the target slide in order to be centred.  However, if `spec.slideWidth` (width of target slide) was less than `spec.listWidth` (which corresponds to the width of the component), the offset amount would be too large for the width of the target slide, and the target slide would be off centre.  

By using `spec.slideWidth` in the calculation instead, the target slide is perfectly centred. 